### PR TITLE
Switch from `futures-cpupool` to `tokio-threadpool`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-hyper"
-version = "0.1.3"
+version = "0.2.0-a.0"
 authors = ["Justin Geibel <jtgeibel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Host a conduit based web application on a hyper server"
@@ -11,8 +11,13 @@ edition = "2018"
 [dependencies]
 conduit = "0.8"
 futures = "0.1"
-futures-cpupool = "0.1"
 hyper = "0.12"
 http = "0.1"
 log = "0.4"
 semver = "0.5" # Must match version in conduit for now
+tokio-threadpool = "0.1.12"
+
+[dev-dependencies]
+conduit = "0.8"
+conduit-router = "0.8"
+tokio = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,5 @@ semver = "0.5" # Must match version in conduit for now
 tokio-threadpool = "0.1.12"
 
 [dev-dependencies]
-conduit = "0.8"
 conduit-router = "0.8"
 tokio = "0.1"

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,0 +1,57 @@
+#![deny(warnings, clippy::all)]
+
+use conduit::{Handler, Request, Response};
+use conduit_hyper::Server;
+use conduit_router::RouteBuilder;
+use futures::Future;
+use tokio::runtime;
+
+use std::collections::HashMap;
+use std::io::{Cursor, Error};
+use std::thread::sleep;
+
+fn main() {
+    let app = build_conduit_handler();
+    let addr = ([127, 0, 0, 1], 12345).into();
+    let server = Server::bind(&addr, app).map_err(|e| {
+        eprintln!("server error: {}", e);
+    });
+
+    let mut rt = runtime::Builder::new()
+        // Set the max number of concurrent requests (tokio defaults to 100)
+        .blocking_threads(2)
+        .build()
+        .unwrap();
+    rt.spawn(server);
+    rt.shutdown_on_idle().wait().unwrap();
+}
+
+fn build_conduit_handler() -> impl Handler {
+    let mut router = RouteBuilder::new();
+    router.get("/", endpoint);
+    router.get("/panic", panic);
+    router
+}
+
+fn endpoint(_: &mut dyn Request) -> Result<Response, Error> {
+    let body = "Hello world!";
+
+    sleep(std::time::Duration::from_secs(2));
+
+    let mut headers = HashMap::new();
+    headers.insert(
+        "Content-Type".to_string(),
+        vec!["text/plain; charset=utf-8".to_string()],
+    );
+    headers.insert("Content-Length".to_string(), vec![body.len().to_string()]);
+    Ok(Response {
+        status: (200, "OK"),
+        headers,
+        body: Box::new(Cursor::new(body)),
+    })
+}
+
+fn panic(_: &mut dyn Request) -> Result<Response, Error> {
+    // For now, connection is immediately closed
+    panic!("message");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,12 +9,26 @@ use std::path::{Component, Path, PathBuf};
 use std::sync::Arc;
 
 use futures::{future, Future, Stream};
-use futures_cpupool::CpuPool;
-use hyper::{Body, Chunk, Method, Request, Response, Server, StatusCode, Version};
+use hyper::{Body, Chunk, Method, Request, Response, StatusCode, Version};
 use log::error;
 
 // Consumers of this library need access to this particular version of `semver`
 pub use semver;
+
+/// A builder for a `hyper::Server`
+#[derive(Debug)]
+pub struct Server;
+
+impl Server {
+    /// Bind a handler to an address
+    pub fn bind<H: conduit::Handler>(
+        addr: &SocketAddr,
+        handler: H,
+    ) -> hyper::Server<hyper::server::conn::AddrIncoming, Service<H>> {
+        let service = Service::new(handler);
+        hyper::Server::bind(&addr).serve(service)
+    }
+}
 
 #[derive(Debug)]
 struct Parts(http::request::Parts);
@@ -67,7 +81,7 @@ struct ConduitRequest {
     parts: Parts,
     path: String,
     body: Cursor<Chunk>,
-    extensions: conduit::Extensions,
+    extensions: conduit::Extensions, // makes struct non-Send
 }
 
 impl conduit::Request for ConduitRequest {
@@ -157,8 +171,34 @@ impl conduit::Request for ConduitRequest {
     }
 }
 
+/// Owned data consumed by the worker thread
+///
+/// `ConduitRequest` cannot be sent between threads, so the input data is
+/// captured on a core thread and taken by the worker thread.
+struct RequestInfo(Option<(Parts, Chunk)>);
+
+impl RequestInfo {
+    /// Save the request info that can be sent between threads
+    fn new(parts: http::request::Parts, body: Chunk) -> Self {
+        let tuple = (Parts(parts), body);
+        Self(Some(tuple))
+    }
+
+    /// Take back the request info
+    ///
+    /// Call this from the worker thread to obtain ownership of the `Send` data
+    ///
+    /// # Panics
+    ///
+    /// Panics if called more than once on a value
+    fn take(&mut self) -> (Parts, Chunk) {
+        self.0.take().expect("called take multiple times")
+    }
+}
+
 impl ConduitRequest {
-    fn new(parts: Parts, body: Chunk) -> ConduitRequest {
+    fn new(info: &mut RequestInfo) -> Self {
+        let (parts, body) = info.take();
         let path = parts.0.uri.path().to_string();
         let path = Path::new(&path);
         let path = path
@@ -183,7 +223,7 @@ impl ConduitRequest {
             .to_string_lossy()
             .to_string(); // non-Unicode is replaced with U+FFFD REPLACEMENT CHARACTER
 
-        ConduitRequest {
+        Self {
             parts,
             path,
             body: Cursor::new(body),
@@ -195,7 +235,6 @@ impl ConduitRequest {
 /// Serve a `conduit::Handler` on a thread pool
 #[derive(Debug)]
 pub struct Service<H> {
-    pool: CpuPool,
     handler: Arc<H>,
 }
 
@@ -203,7 +242,6 @@ pub struct Service<H> {
 impl<H> Clone for Service<H> {
     fn clone(&self) -> Self {
         Service {
-            pool: self.pool.clone(),
             handler: self.handler.clone(),
         }
     }
@@ -230,19 +268,20 @@ impl<H: conduit::Handler> hyper::service::Service for Service<H> {
 
     /// Returns a future which buffers the response body and then calls the conduit handler from a thread pool
     fn call(&mut self, request: Request<Self::ReqBody>) -> Self::Future {
-        let pool = self.pool.clone();
         let handler = self.handler.clone();
 
         let (parts, body) = request.into_parts();
         let response = body.concat2().and_then(move |full_body| {
-            pool.spawn_fn(move || {
-                let mut request = ConduitRequest::new(Parts(parts), full_body);
-                let response = handler
-                    .call(&mut request)
-                    .map(good_response)
-                    .unwrap_or_else(|e| error_response(e.description()));
-
-                Ok(response)
+            let mut request_info = RequestInfo::new(parts, full_body);
+            future::poll_fn(move || {
+                tokio_threadpool::blocking(|| {
+                    let mut request = ConduitRequest::new(&mut request_info);
+                    handler
+                        .call(&mut request)
+                        .map(good_response)
+                        .unwrap_or_else(|e| error_response(e.description()))
+                })
+                .map_err(|_| panic!("the threadpool shut down"))
             })
         });
         Box::new(response)
@@ -250,18 +289,10 @@ impl<H: conduit::Handler> hyper::service::Service for Service<H> {
 }
 
 impl<H: conduit::Handler> Service<H> {
-    /// Create a multi-threaded `Service` from a `Handler`
-    pub fn new(handler: H, threads: usize) -> Service<H> {
+    fn new(handler: H) -> Self {
         Service {
-            pool: CpuPool::new(threads),
             handler: Arc::new(handler),
         }
-    }
-
-    /// Run the `Service` bound to a given `SocketAddr`
-    pub fn run(&self, addr: SocketAddr) {
-        let server = Server::bind(&addr).serve(self.clone());
-        hyper::rt::run(server.map_err(|e| error!("Server error: {}", e)));
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,7 +19,6 @@
 //! use tokio::runtime::Runtime;
 //!
 //! fn main() {
-//!     let a = ();
 //!     let app = build_conduit_handler();
 //!     let addr = ([127, 0, 0, 1], 12345).into();
 //!     let server = Server::bind(&addr, app).map_err(|e| {
@@ -36,21 +35,18 @@
 //! #     Endpoint()
 //! }
 //! #
-//! # use std::collections::HashMap;
-//! # use std::error::Error;
-//! # use std::io::Cursor;
+//! # use std::{collections, error, io};
 //! #
 //! # use conduit::{Request, Response};
 //! #
 //! # struct Endpoint();
 //! #
 //! # impl Handler for Endpoint {
-//! #     fn call(&self, _: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
-//! #         let body = "";
+//! #     fn call(&self, _: &mut dyn Request) -> Result<Response, Box<dyn error::Error + Send>> {
 //! #         Ok(Response {
 //! #             status: (200, "OK"),
-//! #             headers: HashMap::new(),
-//! #             body: Box::new(Cursor::new(body)),
+//! #             headers: collections::HashMap::new(),
+//! #             body: Box::new(io::Cursor::new("")),
 //! #         })
 //! #     }
 //! # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,61 @@
 #![deny(warnings, clippy::all, missing_debug_implementations)]
 
+//! A wrapper for integrating `hyper 0.12` with a `conduit 0.8` blocking application stack.
+//!
+//! A `conduit::Handler` is allowed to block so the `Server` must be spawned on the (default)
+//! multi-threaded `Runtime` which allows (by default) 100 concurrent blocking threads.  Any excess
+//! requests will asynchronously wait for an available blocking thread.
+//!
+//! # Examples
+//!
+//! Try out the example with `cargo run --example server`.
+//!
+//! Typical usage:
+//!
+//! ```no_run
+//! use conduit::Handler;
+//! use conduit_hyper::Server;
+//! use futures::Future;
+//! use tokio::runtime::Runtime;
+//!
+//! fn main() {
+//!     let a = ();
+//!     let app = build_conduit_handler();
+//!     let addr = ([127, 0, 0, 1], 12345).into();
+//!     let server = Server::bind(&addr, app).map_err(|e| {
+//!         eprintln!("server error: {}", e);
+//!     });
+//!
+//!     let mut rt = Runtime::new().unwrap();
+//!     rt.spawn(server);
+//!     rt.shutdown_on_idle().wait().unwrap();
+//! }
+//!
+//! fn build_conduit_handler() -> impl Handler {
+//!     // ...
+//! #     Endpoint()
+//! }
+//! #
+//! # use std::collections::HashMap;
+//! # use std::error::Error;
+//! # use std::io::Cursor;
+//! #
+//! # use conduit::{Request, Response};
+//! #
+//! # struct Endpoint();
+//! #
+//! # impl Handler for Endpoint {
+//! #     fn call(&self, _: &mut dyn Request) -> Result<Response, Box<dyn Error + Send>> {
+//! #         let body = "";
+//! #         Ok(Response {
+//! #             status: (200, "OK"),
+//! #             headers: HashMap::new(),
+//! #             body: Box::new(Cursor::new(body)),
+//! #         })
+//! #     }
+//! # }
+//! ```
+
 #[cfg(test)]
 mod tests;
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,8 +3,7 @@ use std::error::Error;
 use std::io::Cursor;
 
 use conduit::{Handler, Request, Response};
-use futures::{Future, Stream};
-use hyper;
+use futures::{future, Future, Stream};
 
 struct OkResult;
 impl Handler for OkResult {
@@ -73,25 +72,28 @@ fn build_headers(msg: &str) -> HashMap<String, Vec<String>> {
     headers
 }
 
-fn build_threadpool() -> tokio::runtime::Runtime {
-    tokio::runtime::Builder::new()
+fn block_on<F>(f: F)
+where
+    F: FnOnce() -> () + Send + 'static,
+{
+    let mut rt = tokio::runtime::Builder::new()
         .core_threads(1)
         .blocking_threads(1)
         .build()
-        .unwrap()
+        .unwrap();
+    rt.spawn(futures::lazy(move || {
+        f();
+        future::ok(())
+    }));
+    rt.shutdown_on_idle().wait().unwrap();
 }
 
 fn simulate_request<H: Handler>(handler: H) -> hyper::Response<hyper::Body> {
     use hyper::service::{NewService, Service};
 
-    let mut pool = build_threadpool();
-
-    pool.block_on(futures::lazy(|| {
-        let new_service = super::Service::new(handler);
-        let mut service = new_service.new_service().wait().unwrap();
-        service.call(hyper::Request::default()).wait()
-    }))
-    .unwrap()
+    let new_service = super::Service::new(handler);
+    let mut service = new_service.new_service().wait().unwrap();
+    service.call(hyper::Request::default()).wait().unwrap()
 }
 
 fn into_chunk(resp: hyper::Response<hyper::Body>) -> hyper::Chunk {
@@ -107,37 +109,43 @@ fn assert_generic_err(resp: hyper::Response<hyper::Body>) {
 
 #[test]
 fn valid_ok_response() {
-    let resp = simulate_request(OkResult);
-    assert_eq!(resp.status(), 200);
-    assert_eq!(resp.headers().len(), 1);
-    let full_body = into_chunk(resp);
-    assert_eq!(&*full_body, b"Hello, world!");
+    block_on(|| {
+        let resp = simulate_request(OkResult);
+        assert_eq!(resp.status(), 200);
+        assert_eq!(resp.headers().len(), 1);
+        let full_body = into_chunk(resp);
+        assert_eq!(&*full_body, b"Hello, world!");
+    })
 }
 
 #[test]
 fn invalid_ok_responses() {
-    assert_generic_err(simulate_request(InvalidHeader));
-    assert_generic_err(simulate_request(InvalidStatus));
+    block_on(|| {
+        assert_generic_err(simulate_request(InvalidHeader));
+        assert_generic_err(simulate_request(InvalidStatus));
+    })
 }
 
 #[test]
 fn err_responses() {
-    assert_generic_err(simulate_request(ErrorResult));
+    block_on(|| {
+        assert_generic_err(simulate_request(ErrorResult));
+    })
 }
 
 #[ignore] // catch_unwind not yet implemented
 #[test]
 fn recover_from_panic() {
-    assert_generic_err(simulate_request(Panic));
+    block_on(|| {
+        assert_generic_err(simulate_request(Panic));
+    })
 }
 
 #[test]
 fn normalize_path() {
     use hyper::service::{NewService, Service};
 
-    let mut pool = build_threadpool();
-
-    pool.block_on(futures::lazy(|| {
+    block_on(|| {
         let new_service = super::Service::new(AssertPathNormalized);
         let mut service = new_service.new_service().wait().unwrap();
         let req = hyper::Request::put("//removed/.././.././normalized")
@@ -153,7 +161,5 @@ fn normalize_path() {
         let resp = service.call(req).wait().unwrap();
         assert_eq!(resp.status(), 200);
         assert_eq!(resp.headers().len(), 1);
-        Ok::<_, ()>(())
-    }))
-    .unwrap()
+    })
 }


### PR DESCRIPTION
This is a breaking change as the server must now be spawned on a
multi-threaded `tokio::runtime::Runtime`.  Tokio can manage the blocking
threads more efficiently than we can with a separate pool.