### PR TITLE
WIP: Switch to async/await

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ cache:
   cargo: true
 
 rust:
-  - stable
-  - beta
   - nightly
 
 before_install:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,4 +19,5 @@ tokio-threadpool = { git = "https://github.com/tokio-rs/tokio" }
 
 [dev-dependencies]
 conduit-router = "0.8"
+env_logger = "0.6"
 tokio = { git = "https://github.com/tokio-rs/tokio", default-features = false, features = ["rt-full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,11 +11,12 @@ edition = "2018"
 [dependencies]
 conduit = "0.8"
 futures-preview = "0.3.0-alpha.18"
-hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper", rev = "4920f5e264c57f87dc8b91e7ed9a575359cc093c" }
+hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
 http = "0.1"
 log = "0.4"
 semver = "0.5" # Must match version in conduit for now
 tokio-executor = { version = "0.2.0-alpha.2", features = ["threadpool"] }
+tower-service = "0.3.0-alpha.1"
 
 [dev-dependencies]
 conduit-router = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,9 @@ hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
 http = "0.1"
 log = "0.4"
 semver = "0.5" # Must match version in conduit for now
-tokio-threadpool = { git = "https://github.com/tokio-rs/tokio" }
+tokio-threadpool = { version = "0.2.0-alpha.1" }
 
 [dev-dependencies]
 conduit-router = "0.8"
 env_logger = "0.6"
-tokio = { git = "https://github.com/tokio-rs/tokio", default-features = false, features = ["rt-full"] }
+tokio = { version = "0.2.0-alpha.1", default-features = false, features = ["rt-full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 conduit = "0.8"
 futures-preview = "0.3.0-alpha.18"
-hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper", features = ["unstable-stream"] }
+hyper = { version = "0.13.0-alpha.4", features = ["unstable-stream"] }
 http = "0.1"
 tracing = { version = "0.1", features = ["log"] }
 semver = "0.5" # Must match version in conduit for now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-hyper"
-version = "0.2.0-a.0"
+version = "0.2.0-alpha.0"
 authors = ["Justin Geibel <jtgeibel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Host a conduit based web application on a hyper server"
@@ -10,14 +10,14 @@ edition = "2018"
 
 [dependencies]
 conduit = "0.8"
-futures-preview = "0.3.0-alpha.17"
-hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
+futures-preview = "0.3.0-alpha.18"
+hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper", rev = "4920f5e264c57f87dc8b91e7ed9a575359cc093c" }
 http = "0.1"
 log = "0.4"
 semver = "0.5" # Must match version in conduit for now
-tokio-threadpool = { version = "0.2.0-alpha.1" }
+tokio-executor = { version = "0.2.0-alpha.2", features = ["threadpool"] }
 
 [dev-dependencies]
 conduit-router = "0.8"
 env_logger = "0.6"
-tokio = { version = "0.2.0-alpha.1", default-features = false, features = ["rt-full"] }
+tokio = { version = "0.2.0-alpha.2", default-features = false, features = ["rt-full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ edition = "2018"
 
 [dependencies]
 conduit = "0.8"
-futures = "0.1"
-hyper = "0.12"
+futures-preview = "0.3.0-alpha.17"
+hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
 http = "0.1"
 log = "0.4"
 semver = "0.5" # Must match version in conduit for now
-tokio-threadpool = "0.1.12"
+tokio-threadpool = { git = "https://github.com/tokio-rs/tokio" }
 
 [dev-dependencies]
 conduit-router = "0.8"
-tokio = "0.1"
+tokio = { git = "https://github.com/tokio-rs/tokio", default-features = false, features = ["rt-full"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 [dependencies]
 conduit = "0.8"
 futures-preview = "0.3.0-alpha.18"
-hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
+hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper", features = ["unstable-stream"] }
 http = "0.1"
 tracing = { version = "0.1", features = ["log"] }
 semver = "0.5" # Must match version in conduit for now

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ conduit = "0.8"
 futures-preview = "0.3.0-alpha.18"
 hyper = { version = "0.13.0-a.0", git = "https://github.com/hyperium/hyper" }
 http = "0.1"
-log = "0.4"
+tracing = { version = "0.1", features = ["log"] }
 semver = "0.5" # Must match version in conduit for now
 tokio-executor = { version = "0.2.0-alpha.2", features = ["threadpool"] }
 tower-service = "0.3.0-alpha.1"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/jtgeibel/conduit-hyper.svg?branch=master)](https://travis-ci.org/jtgeibel/conduit-hyper)
 
-This crate integrates a `hyper 0.12` server with a `conduit 0.8` application
+This crate integrates a `hyper 0.13` server with a `conduit 0.8` application
 stack.
 
 ## Error and Panic Handling
@@ -30,7 +30,6 @@ The following methods on the `Request` provided to the application have
 noteworthy behavior:
 
 * `scheme` always returns Http as https is not currently directly supported
-* `remote_addr` always returns 0.0.0.0:0
 * `host` returns an empty string if the `Host` header is not valid UTF-8
 
 All other methods on `Request` should behave as expected.

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -22,7 +22,7 @@ fn main() {
         .build()
         .unwrap();
     rt.spawn(async {
-        server.await.unwrap();
+        server.await;
     });
     block_on(rt.shutdown_on_idle());
 }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,5 +1,4 @@
 #![deny(warnings, clippy::all)]
-#![feature(async_await)]
 
 use conduit::{Handler, Request, Response};
 use conduit_hyper::Server;

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -4,7 +4,6 @@
 use conduit::{Handler, Request, Response};
 use conduit_hyper::Server;
 use conduit_router::RouteBuilder;
-use futures::executor::block_on;
 use tokio::runtime;
 
 use std::collections::HashMap;
@@ -26,7 +25,7 @@ fn main() {
     rt.spawn(async {
         server.await;
     });
-    block_on(rt.shutdown_on_idle());
+    rt.shutdown_on_idle();
 }
 
 fn build_conduit_handler() -> impl Handler {

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -12,6 +12,8 @@ use std::io::{Cursor, Error};
 use std::thread::sleep;
 
 fn main() {
+    env_logger::init();
+
     let app = build_conduit_handler();
     let addr = ([127, 0, 0, 1], 12345).into();
     let server = Server::bind(&addr, app);
@@ -31,6 +33,7 @@ fn build_conduit_handler() -> impl Handler {
     let mut router = RouteBuilder::new();
     router.get("/", endpoint);
     router.get("/panic", panic);
+    router.get("/error", error);
     router
 }
 
@@ -55,4 +58,8 @@ fn endpoint(_: &mut dyn Request) -> Result<Response, Error> {
 fn panic(_: &mut dyn Request) -> Result<Response, Error> {
     // For now, connection is immediately closed
     panic!("message");
+}
+
+fn error(_: &mut dyn Request) -> Result<Response, Error> {
+    Err(Error::new(std::io::ErrorKind::Other, "io error, oops"))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,7 +58,7 @@ use std::sync::Arc;
 
 use futures::prelude::*;
 use hyper::{service, Body, Chunk, Method, Request, Response, StatusCode, Version};
-use log::error;
+use tracing::error;
 
 // Consumers of this library need access to this particular version of `semver`
 pub use semver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //! use futures::executor::block_on;
 //! use tokio::runtime::Runtime;
 //!
-//! #[hyper::rt::main]
+//! #[tokio::main]
 //! async fn main() {
 //!     let app = build_conduit_handler();
 //!     let addr = ([127, 0, 0, 1], 12345).into();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -113,7 +113,7 @@ async fn blocking_handler<H: conduit::Handler>(
                     handler
                         .call(&mut request)
                         .map(good_response)
-                        .unwrap_or_else(|e| error_response(e.description()))
+                        .unwrap_or_else(|e| error_response(&e.to_string()))
                 })
                 .map_err(|_| panic!("the threadpool shut down"))
             })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,7 +162,7 @@ async fn blocking_handler<H: conduit::Handler>(
             let mut request_info = RequestInfo::new(parts, full_body);
 
             future::poll_fn(move |_| {
-                tokio_threadpool::blocking(|| {
+                tokio_executor::threadpool::blocking(|| {
                     let mut request = ConduitRequest::new(&mut request_info, remote_addr);
                     handler
                         .call(&mut request)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,10 +133,11 @@ impl Service {
         handler: Arc<H>,
         remote_addr: std::net::SocketAddr,
     ) -> Result<
-        impl service::Service<
-            ReqBody = Body,
-            ResBody = Body,
-            Future = impl Future<Output = Result<(Response<Body>), hyper::Error>>,
+        impl tower_service::Service<
+            Request<Body>,
+            Response = Response<Body>,
+            Error = hyper::Error,
+            Future = impl Future<Output = Result<Response<Body>, hyper::Error>> + Send + 'static,
         >,
         hyper::Error,
     > {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,3 @@
-#![feature(async_await)]
 #![deny(warnings, clippy::all, missing_debug_implementations)]
 
 //! A wrapper for integrating `hyper 0.13` with a `conduit 0.8` blocking application stack.
@@ -14,8 +13,6 @@
 //! Typical usage:
 //!
 //! ```no_run
-//! #![feature(async_await)]
-//!
 //! use conduit::Handler;
 //! use conduit_hyper::Server;
 //! use futures::executor::block_on;
@@ -104,7 +101,6 @@ impl Service {
     /// capturing the socket `remote_addr`.
     ///
     /// ```no_run
-    /// # #![feature(async_await)]
     /// # use std::sync::Arc;
     /// # use conduit_hyper::Service;
     /// # use std::{error, io};

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,6 @@ use std::error::Error;
 use std::io::Cursor;
 
 use conduit::{Handler, Request, Response};
-use futures::executor;
 use futures::prelude::*;
 use hyper::service::Service;
 
@@ -84,7 +83,7 @@ where
         .build()
         .unwrap();
     rt.spawn(future);
-    executor::block_on(rt.shutdown_on_idle());
+    rt.shutdown_on_idle();
 }
 
 fn make_service<H: Handler>(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -89,7 +89,7 @@ where
 fn make_service<H: Handler>(
     handler: H,
 ) -> impl Service<
-    ReqBody = hyper::Body,
+    hyper::Body,
     ResBody = hyper::Body,
     Future = impl Future<Output = Result<hyper::Response<hyper::Body>, hyper::Error>> + Send + 'static,
     Error = hyper::Error,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -100,7 +100,8 @@ fn make_service<H: Handler>(
     let handler = std::sync::Arc::new(handler);
 
     service_fn(move |request: hyper::Request<hyper::Body>| {
-        super::blocking_handler(handler.clone(), request)
+        let remote_addr = ([0, 0, 0, 0], 0).into();
+        super::blocking_handler(handler.clone(), request, remote_addr)
     })
 }
 


### PR DESCRIPTION
Until async/await ships in stable, this branch only runs CI on nightly.  The feature is now stabilized in nightly and should become part of the 1.39 stable release on November 7th.

# TODO

* Once async/await is stable, rebase to remove 2nd commit which limits CI testing to nightly