### PR TITLE
Add support for changes to `conduit::Body`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-conduit = { git = "https://github.com/jtgeibel/conduit", rev = "0deff5b" } # "0.9.0-alpha.2"
+conduit = "0.9.0-alpha.2"
 futures = "0.3"
 hyper = "0.13"
 http = "0.2"
@@ -18,6 +18,6 @@ tokio = { version = "0.2", features = ["blocking", "fs", "rt-threaded", "stream"
 tower-service = "0.3"
 
 [dev-dependencies]
-conduit-router = { git = "https://github.com/jtgeibel/conduit-router", rev = "14b1cc3" } # "0.9.0-alpha.2"
+conduit-router = "0.9.0-alpha.2"
 env_logger = "0.7"
 tokio = { version = "0.2", features = ["macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "conduit-hyper"
-version = "0.3.0-alpha.1"
+version = "0.3.0-alpha.2"
 authors = ["Justin Geibel <jtgeibel@gmail.com>"]
 license = "MIT OR Apache-2.0"
 description = "Host a conduit based web application on a hyper server"
@@ -9,15 +9,15 @@ readme = "README.md"
 edition = "2018"
 
 [dependencies]
-conduit = "0.9.0-alpha.1"
+conduit = { git = "https://github.com/jtgeibel/conduit", rev = "0deff5b" } # "0.9.0-alpha.2"
 futures = "0.3"
 hyper = "0.13"
 http = "0.2"
 tracing = { version = "0.1", features = ["log"] }
-tokio = { version = "0.2", features = ["blocking", "rt-threaded"] }
+tokio = { version = "0.2", features = ["blocking", "fs", "rt-threaded", "stream"] }
 tower-service = "0.3"
 
 [dev-dependencies]
-conduit-router = "0.9.0-alpha.1"
+conduit-router = { git = "https://github.com/jtgeibel/conduit-router", rev = "14b1cc3" } # "0.9.0-alpha.2"
 env_logger = "0.7"
 tokio = { version = "0.2", features = ["macros"] }

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -1,6 +1,6 @@
 #![deny(clippy::all)]
 
-use conduit::{header, static_to_body, Handler, RequestExt, Response, ResponseResult};
+use conduit::{header, Body, Handler, RequestExt, Response, ResponseResult};
 use conduit_hyper::Server;
 use conduit_router::RouteBuilder;
 
@@ -35,7 +35,7 @@ fn endpoint(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {
     Response::builder()
         .header(header::CONTENT_TYPE, "text/plain; charset=utf-8")
         .header(header::CONTENT_LENGTH, body.len())
-        .body(static_to_body(body))
+        .body(Body::from_static(body))
 }
 
 fn panic(_: &mut dyn RequestExt) -> ResponseResult<http::Error> {

--- a/src/file_stream.rs
+++ b/src/file_stream.rs
@@ -1,0 +1,41 @@
+use std::task::{Context, Poll};
+use std::{io::Error, pin::Pin};
+
+use hyper::body::{Body, Bytes};
+use tokio::{fs::File, io::AsyncRead, stream::Stream};
+
+const BUFFER_SIZE: usize = 8 * 1024;
+
+pub struct FileStream {
+    file: File,
+    buffer: Box<[u8; BUFFER_SIZE]>,
+}
+
+impl FileStream {
+    pub fn from_std(file: std::fs::File) -> Self {
+        let buffer = Box::new([0; BUFFER_SIZE]);
+        let file = File::from_std(file);
+        Self { file, buffer }
+    }
+
+    pub fn into_streamed_body(self) -> Body {
+        Body::wrap_stream(self)
+    }
+}
+
+impl Stream for FileStream {
+    type Item = Result<Bytes, Error>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        let Self {
+            ref mut file,
+            ref mut buffer,
+        } = *self;
+        match Pin::new(file).poll_read(cx, &mut buffer[..]) {
+            Poll::Ready(Ok(0)) => Poll::Ready(None),
+            Poll::Ready(Ok(size)) => Poll::Ready(Some(Ok(self.buffer[..size].to_owned().into()))),
+            Poll::Ready(Err(e)) => Poll::Ready(Some(Err(e))),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}

--- a/src/service.rs
+++ b/src/service.rs
@@ -23,12 +23,12 @@ impl Service {
     /// ```no_run
     /// # use std::sync::Arc;
     /// # use conduit_hyper::{BlockingHandler, Service};
-    /// # use conduit::{box_error, static_to_body, Handler, HandlerResult, RequestExt, Response};
+    /// # use conduit::{box_error, Body, Handler, HandlerResult, RequestExt, Response};
     /// #
     /// # struct Endpoint();
     /// # impl Handler for Endpoint {
     /// #     fn call(&self, _: &mut dyn RequestExt) -> HandlerResult {
-    /// #         Response::builder().body(static_to_body(b"")).map_err(box_error)
+    /// #         Response::builder().body(Body::empty()).map_err(box_error)
     /// #     }
     /// # }
     /// # let app = Endpoint();

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,6 +1,4 @@
-use conduit::{
-    box_error, static_to_body, Handler, HandlerResult, RequestExt, Response, StatusCode,
-};
+use conduit::{box_error, Body, Handler, HandlerResult, RequestExt, Response, StatusCode};
 use futures::prelude::*;
 use hyper::{body::to_bytes, service::Service};
 
@@ -12,7 +10,7 @@ impl Handler for OkResult {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .header("ok", "value")
-            .body(static_to_body(b"Hello, world!"))
+            .body(Body::from_static(b"Hello, world!"))
             .map_err(box_error)
     }
 }
@@ -37,7 +35,7 @@ impl Handler for InvalidHeader {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .header("invalid-value", "\r\n")
-            .body(static_to_body(b"discarded"))
+            .body(Body::from_static(b"discarded"))
             .map_err(box_error)
     }
 }
@@ -47,7 +45,7 @@ impl Handler for InvalidStatus {
     fn call(&self, _req: &mut dyn RequestExt) -> HandlerResult {
         Response::builder()
             .status(1000)
-            .body(static_to_body(b""))
+            .body(Body::empty())
             .map_err(box_error)
     }
 }


### PR DESCRIPTION
The new upstream body type allows async servers to provide native
support for streaming the contents of a `File` body.  A `FileStream`
type is added to support this.

r? @JohnTitor
cc conduit-rust/conduit#24
cc conduit-rust/conduit-test#6
cc conduit-rust/conduit-router#7