### PR TITLE
Depend on `futures-util` instead of `futures`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ edition = "2018"
 
 [dependencies]
 conduit = "0.9.0-alpha.2"
-futures = "0.3"
 hyper = "0.13"
 http = "0.2"
 tracing = { version = "0.1", features = ["log"] }
@@ -20,4 +19,5 @@ tower-service = "0.3"
 [dev-dependencies]
 conduit-router = "0.9.0-alpha.2"
 env_logger = "0.7"
+futures-util = "0.3"
 tokio = { version = "0.2", features = ["macros"] }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,5 +1,5 @@
 use conduit::{box_error, Body, Handler, HandlerResult, RequestExt, Response, StatusCode};
-use futures::prelude::*;
+use futures_util::future::{Future, FutureExt};
 use hyper::{body::to_bytes, service::Service};
 
 use super::service::{BlockingHandler, ServiceError};
@@ -150,7 +150,7 @@ async fn limits_thread_count() {
     let first = service.call(hyper::Request::default());
     let second = service.call(hyper::Request::default());
 
-    let first_completed = futures::select! {
+    let first_completed = futures_util::select! {
         // The first thead is spawned and sleeps for 100ms
         sleep = first.fuse() => sleep,
         // The second request is rejected immediately
@@ -171,7 +171,7 @@ async fn sleeping_doesnt_block_another_request() {
     let start = std::time::Instant::now();
 
     // Spawn 2 requests that each sleeps for 100ms
-    let (first, second) = futures::join!(first, second);
+    let (first, second) = futures_util::join!(first, second);
 
     // Elapsed time should be closer to 100ms than 200ms
     assert!(start.elapsed().as_millis() < 150);


### PR DESCRIPTION
Depends on `futures-util` instead of `futures` and moves it to dev-dependencies, to reduce dependencies size. This will allow crates.io to remove `futures` and `futures-executor` from their dependencies.

r? @jtgeibel 