### PR TITLE
Remove rejection of requests when over capacity

### DIFF
--- a/examples/server.rs
+++ b/examples/server.rs
@@ -7,8 +7,6 @@ use conduit_router::RouteBuilder;
 use std::io;
 use std::thread::sleep;
 
-const MAX_THREADS: usize = 1;
-
 #[tokio::main]
 async fn main() {
     env_logger::init();
@@ -16,7 +14,7 @@ async fn main() {
     let app = build_conduit_handler();
     let addr = ([127, 0, 0, 1], 12345).into();
 
-    Server::serve(&addr, app, MAX_THREADS).await;
+    Server::serve(&addr, app).await;
 }
 
 fn build_conduit_handler() -> impl Handler {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,13 +17,11 @@
 //! use conduit_hyper::Server;
 //! use tokio::runtime::Runtime;
 //!
-//! const MAX_THREADS: usize = 10;
-//!
 //! #[tokio::main]
 //! async fn main() {
 //!     let app = build_conduit_handler();
 //!     let addr = ([127, 0, 0, 1], 12345).into();
-//!     let server = Server::serve(&addr, app, MAX_THREADS);
+//!     let server = Server::serve(&addr, app);
 //!
 //!     server.await;
 //! }

--- a/src/server.rs
+++ b/src/server.rs
@@ -19,12 +19,8 @@ impl Server {
     /// `tokio::Runtime` it is not possible to furter configure the `hyper::Server`.  If more
     /// control, such as configuring a graceful shutdown is necessary, then call
     /// `Service::from_blocking` instead.
-    pub fn serve<H: conduit::Handler>(
-        addr: &SocketAddr,
-        handler: H,
-        max_threads: usize,
-    ) -> impl Future {
-        let handler = Arc::new(BlockingHandler::new(handler, max_threads));
+    pub fn serve<H: conduit::Handler>(addr: &SocketAddr, handler: H) -> impl Future {
+        let handler = Arc::new(BlockingHandler::new(handler));
         let make_service = make_service_fn(move |socket: &AddrStream| {
             let handler = handler.clone();
             let remote_addr = socket.remote_addr();

--- a/src/service.rs
+++ b/src/service.rs
@@ -32,8 +32,7 @@ impl Service {
     /// #     }
     /// # }
     /// # let app = Endpoint();
-    /// const MAX_THREADS: usize = 10;
-    /// let handler = Arc::new(BlockingHandler::new(app, MAX_THREADS));
+    /// let handler = Arc::new(BlockingHandler::new(app));
     /// let make_service =
     ///     hyper::service::make_service_fn(move |socket: &hyper::server::conn::AddrStream| {
     ///         let addr = socket.remote_addr();


### PR DESCRIPTION
This functionality was added at a time when tokio 0.2 did not have an
upstream mechanism for limiting the number of threads. The reactor can
now be configured with a maximum number of threads and additional
blocking tasks will be queued until a thread is available. This aligns
with the behavior of `civet`, the other `conduit` based web server.